### PR TITLE
Add more columns to simulations table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 *.pdf
 __pycache__
 venv

--- a/create_empty_database.py
+++ b/create_empty_database.py
@@ -25,6 +25,11 @@ create_table(
         "simulation_unique_id" : "TEXT PRIMARY KEY",
         "simulation_description" : "TEXT NOT NULL",
         "redshift" : "REAL NOT NULL",
+        "feedback_efficiency" : "REAL NOT NULL",
+        "omega_m" : "REAL NOT NULL",
+        "omega_b" : "REAL NOT NULL",
+        "box_size" : "REAL NOT NULL",
+        "resolution" : "REAL NOT NULL",
     },
 )
 

--- a/populate_profile_data.py
+++ b/populate_profile_data.py
@@ -30,10 +30,10 @@ illstack_global_properties = get_illstack_global_properties(profile_filename)
 populate_table(
     "simulations",
     [
-        "simulation_unique_id", "simulation_description", "redshift"
+        "simulation_unique_id", "simulation_description", "redshift", "feedback_efficiency", "omega_m", "omega_b", "box_size", "resolution"
     ],
     [
-        (SIMULATION_ID, SIMULATION_DESCRIPTION, SIMULATION_REDSHIFT)
+        (SIMULATION_ID, SIMULATION_DESCRIPTION, SIMULATION_REDSHIFT, 0.3, 0.3, 0.05, 100, 1)
     ]
 )
 

--- a/sample_end_to_end.py
+++ b/sample_end_to_end.py
@@ -1,9 +1,11 @@
 import matplotlib.pyplot as plt
 from filter_data_helpers import get_halos_based_on_filters, get_profiles
 
+HUBBLE = 0.6711
+
 # Select halos based on mass cut and simulation ID
 halo_ids_result = get_halos_based_on_filters(
-    list_of_inequality_filters=[("M_Crit200", 100, 1e3)],
+    list_of_inequality_filters=[("M_Crit200", 100/HUBBLE, 1e3/HUBBLE)],
     list_of_equality_filters=[("simulation_id", ["sample simulation ID"])]
 )
 print(halo_ids_result)
@@ -24,10 +26,26 @@ profiles_result = get_profiles(
 
 print(profiles_result)
 
+# Rescale data to common units
+profiles_result["radius"] *= 1 / (HUBBLE * 1e3) # Convert to Mpc
+profiles_result["property_value"] *= 1e10 * HUBBLE * HUBBLE # Convert to Msun * kpc^-3
+
 # Plot profiles for different halos
 profiles_result = profiles_result.pivot(index="radius", columns="halo_unique_id", values="property_value")
 print(profiles_result)
 
-profiles_result.plot(logx=True)
+# Filter radial values
+profiles_result = profiles_result[(profiles_result.index > 0.01) & (profiles_result.index < 3)]
+
+
+# Compute percentiles of profile data
+profiles_16 = profiles_result.quantile(q=0.16, axis="columns")
+profiles_84 = profiles_result.quantile(q=0.84, axis="columns")
+profiles_median = profiles_result.quantile(q=0.5, axis="columns")
+
+
+profiles_16.plot(logx=True)
+profiles_84.plot(logx=True)
+profiles_median.plot(logx=True)
 
 plt.show()

--- a/sample_end_to_end.py
+++ b/sample_end_to_end.py
@@ -5,7 +5,7 @@ HUBBLE = 0.6711
 
 # Select halos based on mass cut and simulation ID
 halo_ids_result = get_halos_based_on_filters(
-    list_of_inequality_filters=[("M_Crit200", 100/HUBBLE, 1e3/HUBBLE)],
+    list_of_inequality_filters=[("M_Crit200", 1/HUBBLE, 1e5/HUBBLE)],
     list_of_equality_filters=[("simulation_id", ["sample simulation ID"])]
 )
 print(halo_ids_result)
@@ -38,14 +38,34 @@ print(profiles_result)
 profiles_result = profiles_result[(profiles_result.index > 0.01) & (profiles_result.index < 3)]
 
 
-# Compute percentiles of profile data
-profiles_16 = profiles_result.quantile(q=0.16, axis="columns")
-profiles_84 = profiles_result.quantile(q=0.84, axis="columns")
-profiles_median = profiles_result.quantile(q=0.5, axis="columns")
+# Bin halo_IDs by M_Crit200
+mass_ranges = [(0, 2), (2, 10), (10, 100), (100, 1000)]
+halo_IDs_bins = [list(halo_ids_result[(halo_ids_result["M_Crit200"] >= low) & (halo_ids_result["M_Crit200"] < high)]["halo_unique_id"]) for (low, high) in mass_ranges]
+print(halo_IDs_bins)
+
+# Compute and plot percentiles of profile data
+fig, ax = plt.subplots(1, 1, figsize=(8, 5))
 
 
-profiles_16.plot(logx=True)
-profiles_84.plot(logx=True)
-profiles_median.plot(logx=True)
+for mass_range, halo_IDs_bin in zip(mass_ranges, halo_IDs_bins):
+    low, high = mass_range
 
+    binned_profiles = profiles_result[halo_IDs_bin]
+    print(binned_profiles)
+
+    profiles_16 = binned_profiles.quantile(q=0.16, axis="columns")
+    profiles_84 = binned_profiles.quantile(q=0.84, axis="columns")
+    profiles_median = binned_profiles.quantile(q=0.5, axis="columns")
+    print(profiles_16)
+
+    ax.fill_between(profiles_16.index, profiles_16, profiles_84, alpha=0.2)
+    profiles_median.plot(label=f"{low} <=" + r" $M_{200c}/(10^{10} \cdot M_{\odot}) <$" + f" {high}")
+
+# Display plot
+ax.set_xscale("log")
+ax.set_yscale("log")
+ax.set_xlabel(r"$r$ (Mpc)")
+ax.set_ylabel(r"$\rho_{gas}$ ($M_{\odot} \cdot kpc^{-3}$)")
+
+plt.legend()
 plt.show()


### PR DESCRIPTION
Changes:
- Add more columns to the `simulations` table
- Create a prettier, more useful plot in `sample_end_to_end.py`, which shows gas density profiles for halos binned by `M200c`